### PR TITLE
Fix Qwen2.5-Omni implementation bugs and optimize input order for >10% performance boost

### DIFF
--- a/test_model/Qwen2.5-Omni/testmodel.py
+++ b/test_model/Qwen2.5-Omni/testmodel.py
@@ -1,6 +1,7 @@
 import torch
 # Updated imports for Qwen2.5 Omni
-from transformers import Qwen2_5OmniModel, Qwen2_5OmniProcessor
+from transformers import Qwen2_5OmniProcessor
+from transformers import Qwen2_5OmniForConditionalGeneration
 # Assuming qwen_omni_utils contains process_mm_info
 # Make sure this import works in your environment
 try:
@@ -146,10 +147,12 @@ Your answer should be a capital letter representing your choice: A, B, C, or D. 
 """
         # Updated conversation structure for Omni
         conversation= [
-            {"role": "system", "content": 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'},
+            {"role": "system", "content": [
+                {"type": "text", "text": 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'},
+            ]},
             {"role": "user", "content": [
-                {"type":"text","text":prompt},
-                {"type":"video", "video": video_path}
+                {"type":"video", "video": video_path},
+                {"type":"text","text":prompt}
             ]},
         ]
         model_answer = None # Initialize model_answer
@@ -157,7 +160,7 @@ Your answer should be a capital letter representing your choice: A, B, C, or D. 
             text = processor.apply_chat_template(conversation, add_generation_prompt=True, tokenize=False)
             # Use use_audio_in_video from args
             audios, images, videos = process_mm_info(conversation, use_audio_in_video=args.use_audio_in_video)
-            inputs = processor(text=text, audios=audios, images=images, videos=videos, return_tensors="pt", padding=True)
+            inputs = processor(text=text, audio=audios, images=images, videos=videos, return_tensors="pt", padding=True, use_audio_in_video=args.use_audio_in_video)
             inputs = inputs.to(model.device).to(model.dtype)
 
             # Inference
@@ -361,7 +364,7 @@ if __name__ == "__main__":
     print(f"Enable audio output: {not args.disable_audio_output}")
 
     try:
-        model = Qwen2_5OmniModel.from_pretrained(
+        model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
             args.model_name_or_path,
             device_map=args.device,
             torch_dtype=torch_dtype,


### PR DESCRIPTION
This PR fixes several critical issues in `test_model/Qwen2.5-Omni/testmodel.py` and significantly improves the evaluation results.

### Key Changes

1.  **Correct Model Class Import**:
    -   Changed the import from `Qwen2_5OmniModel` (incorrect) to `Qwen2_5OmniForConditionalGeneration` (correct).

2.  **Fix Audio Processing (Critical)**:
    -   **Issue**: The original code missed the `use_audio_in_video` parameter and used incorrect processor arguments `audios`. This caused the model to **ignore audio information**.
    -   **Fix**: Corrected the processor argument to `audio` and explicitly added `use_audio_in_video=args.use_audio_in_video`.
 https://github.com/huggingface/transformers/blob/v5.1.0/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py#L230   https://huggingface.co/docs/transformers/model_doc/qwen2_5_omni#transformers.Qwen2_5OmniProcessor.__call__.use_audio_in_video
https://huggingface.co/docs/transformers/model_doc/qwen2_5_omni#transformers.Qwen2_5OmniProcessor.__call__.audio
   
3.  **Optimize Modality Order (Critical)**:
    -   **Issue**: I observed that the input order of `video` and `text` in the conversation list critically impacts performance.
    -   **Fix**: Swapped the order to place **`video` input before the `text` prompt**.
    -   **Result**: This aligns with the model's training/inference expectations and yields a >10% improvement.
    - According to https://huggingface.co/docs/transformers/model_doc/qwen2_5_omni

## Reproduction Settings & Environment

To ensure reproducibility, I verified the results across different hardware configurations:

-   **Hardware Verified**:
    -   RTX 4090 (48GB)
    -   RTX 3090
    -   *Note: Results were consistent across both GPU environments.*

-   **Preprocessing Settings**:
      VIDEO_MIN_PIXELS = 128 * 28 * 28
      VIDEO_MAX_PIXELS = 128 * 28 * 28
      FRAME_FACTOR = 2
      FPS = 2.0
      FPS_MIN_FRAMES = 4
      FPS_MAX_FRAMES = 128
### 🔬 Qwen2.5-Omni 7B Performance Ablation Study

To evaluate the impact of the fixes, I conducted an ablation study on the 7B model across four scenarios. This highlights the specific contributions of the **modality order** (Text vs. Video priority) and the **`use_audio_in_video`** parameter.

| Case | Conversation Order | `use_audio_in_video` | Performance Analysis |
| :--- | :--- | :---: | :--- |
| **1. Baseline (Original)** | `Text` ➡️ `Video` | `False` | 40.52% |
| **2. Audio Fix Only** | `Text` ➡️ `Video` | `True` | 46.87% |
| **3. Order Fix Only** | **`Video` ➡️ `Text`** | `False` | 47.7% |
| **4. Proposed Fix (This PR)** | **`Video` ➡️ `Text`** | **`True`** | 62.07%🚀  |

> **Conclusion**: While enabling audio is necessary for correctness, the **modality order swap (Video before Text)** is the dominant factor driving the performance improvements.

## Performance Evidence (Screenshots)

The following screenshots demonstrate the significant performance boost on both 3B and 7B models after applying the fixes (especially the modality order swap).

### Qwen2.5-Omni 7B Comparison
| Original Order (Text First) | Optimized Order (Video First) |
| :---: | :---: |
| <img width="574" height="852" alt="image" src="https://github.com/user-attachments/assets/1aa46829-b16e-44a2-a63b-806e30875b42" /> | <img width="568" height="854" alt="image" src="https://github.com/user-attachments/assets/5e06c66e-fcfe-47b9-b0cb-f4ff7d017c46" /> |


### Qwen2.5-Omni 3B Comparison
| Original Order (Text First) | Optimized Order (Video First) |
| :---: | :---: |
| <img width="584" height="770" alt="image" src="https://github.com/user-attachments/assets/e37f2cf1-32ee-47b4-85b3-8b3c2cf52682" />| <img width="576" height="862" alt="image" src="https://github.com/user-attachments/assets/d3730eca-ccde-41f4-ac35-eff0fb933d9a" /> |

> **Note**: As shown above, the optimized order achieves significantly higher scores across the metrics.